### PR TITLE
Escape only quotes in string values

### DIFF
--- a/influx_line_protocol/metric.py
+++ b/influx_line_protocol/metric.py
@@ -48,18 +48,20 @@ class Metric(object):
 
         return protocol
 
-    def __escape(self, value, escape_only_quotes=False):
+    def __escape(self, value):
         # Escape backslashes first since the other characters are escaped with
         # backslashes
         new_value = value.replace('\\', '\\\\')
 
-        if escape_only_quotes:
-            new_value = new_value.replace('"', '\\"')
-            return new_value
-
         new_value = new_value.replace(' ', '\\ ')
         new_value = new_value.replace('=', '\\=')
         new_value = new_value.replace(',', '\\,')
+
+        return new_value
+
+    def __escape_value(self, value):
+        new_value = value.replace('\\', '\\\\')
+        new_value = new_value.replace('"', '\\"')
 
         return new_value
 
@@ -73,4 +75,4 @@ class Metric(object):
         if type(value) is bool:
             return value and "t" or "f"
 
-        return "\"%s\"" % self.__escape(value, True)
+        return "\"%s\"" % self.__escape_value(value)

--- a/influx_line_protocol/metric.py
+++ b/influx_line_protocol/metric.py
@@ -48,16 +48,18 @@ class Metric(object):
 
         return protocol
 
-    def __escape(self, value, escape_quotes=False):
+    def __escape(self, value, escape_only_quotes=False):
         # Escape backslashes first since the other characters are escaped with
         # backslashes
         new_value = value.replace('\\', '\\\\')
+
+        if escape_only_quotes:
+            new_value = new_value.replace('"', '\\"')
+            return new_value
+
         new_value = new_value.replace(' ', '\\ ')
         new_value = new_value.replace('=', '\\=')
         new_value = new_value.replace(',', '\\,')
-
-        if escape_quotes:
-            new_value = new_value.replace('"', '\\"')
 
         return new_value
 

--- a/influx_line_protocol/test_metric.py
+++ b/influx_line_protocol/test_metric.py
@@ -67,6 +67,18 @@ class TestMetric(unittest.TestCase):
 
         self.assertEqual("test x=\"z\\\\\\\"\"", str(metric))
 
+    def test_metric_escape_field_double_quotes_and_space(self):
+        metric = Metric("test")
+        metric.add_value("x", "foo bar")
+
+        self.assertEqual("test x=\"foo bar\"", str(metric))
+
+    def test_metric_escape_field_double_quotes_with_equal_sign_and_comma(self):
+        metric = Metric("test")
+        metric.add_value("x", "a=b,c=d,e=f")
+
+        self.assertEqual("test x=\"a=b,c=d,e=f\"", str(metric))
+
     def test_metric_with_tag_value_and_timestamp(self):
         metric = Metric("test")
         metric.add_tag("tag", "string")


### PR DESCRIPTION
#11 introducted escaping to field values, which resulted in extra slashes in strings. As [documentation](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#special-characters) states, only double quotes need to be escaped in string values.