### PR TITLE
change level of precision on output of floats

### DIFF
--- a/influx_line_protocol/metric.py
+++ b/influx_line_protocol/metric.py
@@ -69,7 +69,7 @@ class Metric(object):
             return "%di" % value
 
         if type(value) is float:
-            return "%g" % value
+            return "%f" % value
 
         if type(value) is bool:
             return value and "t" or "f"


### PR DESCRIPTION
The %g only gives 6 digits of precision of floats which isn't enough for lat long data. Change it to %f returns double precision float data.